### PR TITLE
Set up config framework

### DIFF
--- a/database/factories/JobStatusFactory.php
+++ b/database/factories/JobStatusFactory.php
@@ -26,7 +26,8 @@ class JobStatusFactory extends Factory
             'uuid' => Str::uuid(),
             'job_id' => $this->faker->numberBetween(1, 10000000),
             'connection_name' => 'database',
-            'status' => Status::QUEUED
+            'status' => Status::QUEUED,
+            'configuration' => []
         ];
     }
 }

--- a/database/migrations/2023_01_15_232222_add_configuration_to_job_status_table.php
+++ b/database/migrations/2023_01_15_232222_add_configuration_to_job_status_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     *
+     */
+    public function up()
+    {
+        Schema::table(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_statuses'), function (Blueprint $table) {
+            $table->text('configuration')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     */
+    public function down()
+    {
+        Schema::table(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_statuses'), function (Blueprint $table) {
+            $table->dropColumn('configuration');
+        });
+    }
+};

--- a/src/Concerns/Trackable.php
+++ b/src/Concerns/Trackable.php
@@ -15,6 +15,11 @@ trait Trackable
 
     public ?JobStatus $jobStatus = null;
 
+    public function getJobStatusConfiguration(): array
+    {
+        return [];
+    }
+
     public static function search(array $tags = []): JobStatusSearcher
     {
         $search = app(JobStatusSearcher::class)->whereJobClass(static::class);

--- a/src/Listeners/BaseListener.php
+++ b/src/Listeners/BaseListener.php
@@ -76,7 +76,6 @@ class BaseListener
             $jobStatus = app(JobStatusRepository::class)->getLatestByUuid($job->uuid());
         }
         if($jobStatus === null && $job->getConnectionName() === 'sync') {
-            $command = null;
             if (str_starts_with($job->payload()['data']['command'], 'O:')) {
                 $command = unserialize($job->payload()['data']['command']);
             } elseif (App::bound(Encrypter::class)) {
@@ -91,7 +90,8 @@ class BaseListener
                 'status' => Status::QUEUED,
                 'uuid' => $job->uuid(),
                 'connection_name' => $job->getConnectionName(),
-                'job_id' => $job->getJobId()
+                'job_id' => $job->getJobId(),
+                'configuration' => $command->getJobStatusConfiguration()
             ]);
             JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
             foreach ($command->tags() as $key => $value) {

--- a/src/Listeners/JobQueued.php
+++ b/src/Listeners/JobQueued.php
@@ -41,7 +41,8 @@ class JobQueued extends BaseListener
                 'status' => Status::QUEUED,
                 'uuid' => null,
                 'job_id' => $event->id,
-                'connection_name' => $event->connectionName
+                'connection_name' => $event->connectionName,
+                'configuration' => $job->getJobStatusConfiguration()
             ]);
 
             $modifier = JobStatusModifier::forJobStatus($jobStatus);

--- a/src/Models/JobStatus.php
+++ b/src/Models/JobStatus.php
@@ -25,14 +25,15 @@ class JobStatus extends Model
     use HasFactory;
 
     protected $fillable = [
-        'job_class', 'job_alias', 'percentage', 'status', 'uuid', 'job_id', 'connection_name'
+        'job_class', 'job_alias', 'percentage', 'status', 'uuid', 'job_id', 'connection_name', 'configuration'
     ];
 
     protected $casts = [
         'percentage' => 'float',
         'updated_at' => 'datetime:Y-m-d H:i:s',
         'created_at' => 'datetime:Y-m-d H:i:s',
-        'status' => Status::class
+        'status' => Status::class,
+        'configuration' => 'array'
     ];
 
     public function __construct(array $attributes = [])
@@ -204,4 +205,5 @@ class JobStatus extends Model
 
         return ($this->job_class)::canSeeTracking($user, $this->getTagsAsArray());
     }
+
 }


### PR DESCRIPTION
Let you store config in the job status.

Was going to use it for keepOldJobStatuses, but I believe that'll nearly always be the case and is mostly handled with deleting old jobs, so leaving it until it's needed.