### PR TITLE
Limit a users ability to see jobs to only those they need to see

### DIFF
--- a/.github/workflows/phpstan_analysis.yml
+++ b/.github/workflows/phpstan_analysis.yml
@@ -10,7 +10,6 @@ jobs:
             matrix:
                 php: [ '8.1', '8.2' ]
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[CI]')"
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/phpunit_tests.yml
+++ b/.github/workflows/phpunit_tests.yml
@@ -10,7 +10,6 @@ jobs:
             matrix:
                 php: [ '8.1', '8.2' ]
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[CI]')"
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/trigger_pr_flow.yml
+++ b/.github/workflows/trigger_pr_flow.yml
@@ -5,14 +5,11 @@ on:
 
 jobs:
     php-linter:
-        if: "!contains(github.event.head_commit.message, '[CI - PHP Linting]')"
         uses: ./.github/workflows/linting.yml
         secrets: inherit
     run-tests:
-        if: "!contains(github.event.head_commit.message, '[CI]')"
         uses: ./.github/workflows/phpunit_tests.yml
         needs: [php-linter]
     static-analysis:
-        if: "!contains(github.event.head_commit.message, '[CI]')"
         uses: ./.github/workflows/phpstan_analysis.yml
         needs: [php-linter]

--- a/database/factories/JobStatusFactory.php
+++ b/database/factories/JobStatusFactory.php
@@ -27,6 +27,7 @@ class JobStatusFactory extends Factory
             'job_id' => $this->faker->numberBetween(1, 10000000),
             'connection_name' => 'database',
             'status' => Status::QUEUED,
+            'public' => true,
             'configuration' => [],
         ];
     }

--- a/database/factories/JobStatusUserFactory.php
+++ b/database/factories/JobStatusUserFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JobStatus\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use JobStatus\Models\JobStatus;
+use JobStatus\Models\JobStatusUser;
+
+class JobStatusUserFactory extends Factory
+{
+    protected $model = JobStatusUser::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => $this->faker->numberBetween(1, 100),
+            'job_status_id' => JobStatus::factory(),
+        ];
+    }
+}

--- a/database/migrations/2022_07_24_001000_create_job_statuses_table.php
+++ b/database/migrations/2022_07_24_001000_create_job_statuses_table.php
@@ -21,6 +21,7 @@ return new class() extends Migration {
             $table->timestamp('started_at', 3)->nullable();
             $table->timestamp('finished_at', 3)->nullable();
             $table->string('job_id');
+            $table->boolean('public')->default(true);
             $table->text('configuration')->nullable();
             $table->string('connection_name');
             $table->timestamps(3);

--- a/database/migrations/2023_01_29_220021_create_job_status_users_table.php
+++ b/database/migrations/2023_01_29_220021_create_job_status_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     *
+     */
+    public function up()
+    {
+        Schema::create(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_status_users'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('job_status_id');
+            $table->timestamps();
+        });
+
+        Schema::table(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_status_users'), function (Blueprint $table) {
+            $table->foreign('job_status_id')->references('id')->on(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_statuses'))->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     */
+    public function down()
+    {
+        Schema::dropIfExists(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_status_users'));
+    }
+};

--- a/src/Concerns/Trackable.php
+++ b/src/Concerns/Trackable.php
@@ -64,11 +64,6 @@ trait Trackable
         return new JobStatusModifier($this->getJobStatus());
     }
 
-    public static function canSeeTracking($user = null, array $tags = []): bool
-    {
-        return true;
-    }
-
     public function alias(): ?string
     {
         return get_class($this);
@@ -77,5 +72,15 @@ trait Trackable
     public function tags(): array
     {
         return [];
+    }
+
+    public function users(): array
+    {
+        return [];
+    }
+
+    public function public(): bool
+    {
+        return true;
     }
 }

--- a/src/Dashboard/Http/Controllers/Api/HistoryController.php
+++ b/src/Dashboard/Http/Controllers/Api/HistoryController.php
@@ -10,6 +10,7 @@ class HistoryController extends Controller
     public function __invoke()
     {
         return JobStatusSearcher::query()
+            ->withoutUserLimit()
             ->get()
             ->runs();
     }

--- a/src/Dashboard/Http/Controllers/Api/RunController.php
+++ b/src/Dashboard/Http/Controllers/Api/RunController.php
@@ -14,6 +14,7 @@ class RunController extends Controller
         $jobStatus = JobStatus::findOrFail($jobStatusId);
         if ($jobStatus->uuid) {
             return JobStatusSearcher::query()
+                ->withoutUserLimit()
                 ->whereUuid($jobStatus->uuid)
                 ->get()
                 ->firstRun();

--- a/src/Dashboard/Http/Controllers/Api/TrackedJobController.php
+++ b/src/Dashboard/Http/Controllers/Api/TrackedJobController.php
@@ -10,12 +10,14 @@ class TrackedJobController extends Controller
     public function index()
     {
         return JobStatusSearcher::query()
+            ->withoutUserLimit()
             ->get();
     }
 
     public function show(string $alias)
     {
         return JobStatusSearcher::query()
+            ->withoutUserLimit()
             ->whereJobAlias($alias)
             ->get()
             ->first();

--- a/src/Dashboard/Http/Middleware/Authenticate.php
+++ b/src/Dashboard/Http/Middleware/Authenticate.php
@@ -9,6 +9,6 @@ class Authenticate
 {
     public function handle(Request $request, $next)
     {
-        return (app()->environment('test') || Gate::allows('viewJobStatus')) ? $next($request) : abort(403);
+        return (app()->environment('local') || Gate::allows('viewJobStatus')) ? $next($request) : abort(403);
     }
 }

--- a/src/Http/Controllers/JobSignalController.php
+++ b/src/Http/Controllers/JobSignalController.php
@@ -34,10 +34,7 @@ class JobSignalController
         $userId = $this->resolveAuth();
         $jobRun = new JobRun($jobStatus);
 
-        if(
-            ($userId === null && !$jobStatus->public)
-            || $userId !== null && !$jobRun->accessibleBy($userId)
-        ) {
+        if(!$jobRun->accessibleBy($userId)) {
             throw new AuthorizationException('You cannot access this job status', 403);
         }
     }

--- a/src/Http/Controllers/JobSignalController.php
+++ b/src/Http/Controllers/JobSignalController.php
@@ -2,19 +2,43 @@
 
 namespace JobStatus\Http\Controllers;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Auth;
 use JobStatus\Http\Requests\JobSignalStoreRequest;
 use JobStatus\JobStatusModifier;
+use JobStatus\JobStatusServiceProvider;
 use JobStatus\Models\JobStatus;
+use JobStatus\Search\Result\JobRun;
 
 class JobSignalController
 {
     public function store(JobSignalStoreRequest $request, JobStatus $jobStatus)
     {
+        $this->authenticateUserWithJob($jobStatus);
+
         $modifier = JobStatusModifier::forJobStatus($jobStatus);
         $modifier->sendSignal(
             signal: $request->input('signal'),
             parameters: $request->input('parameters', []),
             cancel: $request->input('cancel_job'),
         );
+    }
+
+    public function resolveAuth(): ?int
+    {
+        return call_user_func(JobStatusServiceProvider::$resolveAuthWith ?? fn () => Auth::user()?->id);
+    }
+
+    private function authenticateUserWithJob(JobStatus $jobStatus)
+    {
+        $userId = $this->resolveAuth();
+        $jobRun = new JobRun($jobStatus);
+
+        if(
+            ($userId === null && !$jobStatus->public)
+            || $userId !== null && !$jobRun->accessibleBy($userId)
+        ) {
+            throw new AuthorizationException('You cannot access this job status', 403);
+        }
     }
 }

--- a/src/Http/Controllers/JobStatusController.php
+++ b/src/Http/Controllers/JobStatusController.php
@@ -13,7 +13,7 @@ class JobStatusController extends Controller
     public function search(JobStatusSearchRequest $request)
     {
         $searcher = JobStatusSearcher::query()
-            ->forUser(Auth::user()?->id)
+            ->forUser($this->resolveAuth())
             ->whereJobAlias($request->input('alias'));
 
         if ($request->has('tags')) {

--- a/src/Http/Controllers/JobStatusController.php
+++ b/src/Http/Controllers/JobStatusController.php
@@ -3,7 +3,9 @@
 namespace JobStatus\Http\Controllers;
 
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 use JobStatus\Http\Requests\JobStatusSearchRequest;
+use JobStatus\JobStatusServiceProvider;
 use JobStatus\Search\JobStatusSearcher;
 
 class JobStatusController extends Controller
@@ -11,6 +13,7 @@ class JobStatusController extends Controller
     public function search(JobStatusSearchRequest $request)
     {
         $searcher = JobStatusSearcher::query()
+            ->forUser(Auth::user()?->id)
             ->whereJobAlias($request->input('alias'));
 
         if ($request->has('tags')) {
@@ -23,5 +26,10 @@ class JobStatusController extends Controller
         }
 
         return $result->toArray();
+    }
+
+    public function resolveAuth(): ?int
+    {
+        return call_user_func(JobStatusServiceProvider::$resolveAuthWith ?? fn () => Auth::user()?->id);
     }
 }

--- a/src/JobStatusModifier.php
+++ b/src/JobStatusModifier.php
@@ -6,6 +6,7 @@ use JobStatus\Enums\MessageType;
 use JobStatus\Enums\Status;
 use JobStatus\Models\JobException;
 use JobStatus\Models\JobStatus;
+use JobStatus\Models\JobStatusUser;
 
 class JobStatusModifier
 {
@@ -204,6 +205,19 @@ class JobStatusModifier
     {
         if ($this->jobStatus !== null) {
             $this->jobStatus->connection_name = $connectionName;
+            $this->jobStatus->save();
+        }
+
+        return $this;
+    }
+
+    public function grantAccessTo(int $userId)
+    {
+        if ($this->jobStatus !== null) {
+            JobStatusUser::updateOrCreate([
+                'user_id' => $userId,
+                'job_status_id' => $this->jobStatus->id
+            ]);
             $this->jobStatus->save();
         }
 

--- a/src/Listeners/BaseListener.php
+++ b/src/Listeners/BaseListener.php
@@ -92,13 +92,18 @@ class BaseListener
                 'connection_name' => $job->getConnectionName(),
                 'job_id' => $job->getJobId(),
                 'configuration' => $command->getJobStatusConfiguration(),
+                'public' => $command->public()
             ]);
-            JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
+            $modifier = JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
             foreach ($command->tags() as $key => $value) {
                 $jobStatus->tags()->create([
                     'key' => $key,
                     'value' => $value,
                 ]);
+            }
+
+            foreach($command->users() as $user) {
+                $modifier->grantAccessTo($user);
             }
         }
 

--- a/src/Listeners/JobProcessed.php
+++ b/src/Listeners/JobProcessed.php
@@ -30,6 +30,7 @@ class JobProcessed extends BaseListener
 
             if ($modifier->getJobStatus()->status === Status::STARTED) {
                 $modifier->setFinishedAt(now());
+                $modifier->setPercentage(100.0);
                 if ($event->job->hasFailed()) {
                     $modifier->setStatus(Status::FAILED);
                 } else {
@@ -46,15 +47,20 @@ class JobProcessed extends BaseListener
                     'uuid' => $event->job->uuid(),
                     'connection_name' => $event->job->getConnectionName(),
                     'job_id' => $event->job->getJobId(),
+                    'public' => $modifier->getJobStatus()?->public
                 ]);
 
-                JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
+                $newModifier = JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
 
                 foreach ($modifier->getJobStatus()->tags()->get() as $tag) {
                     $jobStatus->tags()->create([
                         'key' => $tag->key,
                         'value' => $tag->value,
                     ]);
+                }
+
+                foreach($modifier->getJobStatus()?->users()->get() as $user) {
+                    $newModifier->grantAccessTo($user->user_id);
                 }
             }
 

--- a/src/Listeners/JobQueued.php
+++ b/src/Listeners/JobQueued.php
@@ -4,6 +4,7 @@ namespace JobStatus\Listeners;
 
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Facades\Queue;
+use JobStatus\Concerns\Trackable;
 use JobStatus\Enums\Status;
 use JobStatus\JobStatusModifier;
 use JobStatus\Models\JobStatus;
@@ -22,6 +23,7 @@ class JobQueued extends BaseListener
     public function handle(\Illuminate\Queue\Events\JobQueued $event)
     {
         if ($this->isTrackingEnabled()) {
+            /** @var Trackable $job */
             $job = $event->job;
 
             if ($this->validateJob($job) === false) {
@@ -37,10 +39,15 @@ class JobQueued extends BaseListener
                 'job_id' => $event->id,
                 'connection_name' => $event->connectionName,
                 'configuration' => $job->getJobStatusConfiguration(),
+                'public' => $job->public()
             ]);
 
             $modifier = JobStatusModifier::forJobStatus($jobStatus);
             $modifier->setStatus(Status::QUEUED);
+
+            foreach($job->users() as $user) {
+                $modifier->grantAccessTo($user);
+            }
 
             foreach ($job->tags() as $key => $value) {
                 $jobStatus->tags()->create([

--- a/src/Listeners/JobReleasedAfterException.php
+++ b/src/Listeners/JobReleasedAfterException.php
@@ -31,7 +31,9 @@ class JobReleasedAfterException extends BaseListener
                 'uuid' => $event->job->uuid(),
                 'connection_name' => $event->job->getConnectionName(),
                 'job_id' => $event->job->getJobId(),
+                'public' => $modifier->getJobStatus()?->public
             ]);
+
 
             JobStatusModifier::forJobStatus($jobStatus)->setStatus(Status::QUEUED);
 
@@ -39,6 +41,12 @@ class JobReleasedAfterException extends BaseListener
                 $jobStatus->tags()->create([
                     'key' => $tag->key,
                     'value' => $tag->value,
+                ]);
+            }
+
+            foreach ($modifier->getJobStatus()->users()->get() as $user) {
+                $jobStatus->users()->create([
+                    'user_id' => $user->user_id,
                 ]);
             }
         }

--- a/src/Models/JobStatus.php
+++ b/src/Models/JobStatus.php
@@ -21,10 +21,11 @@ class JobStatus extends Model
 
     protected $fillable = [
         'job_class', 'job_alias', 'percentage', 'status', 'uuid', 'job_id', 'connection_name', 'configuration', 'exception_id',
-        'started_at', 'finished_at',
+        'started_at', 'finished_at', 'public'
     ];
 
     protected $casts = [
+        'public' => 'boolean',
         'percentage' => 'float',
         'updated_at' => 'datetime:Y-m-d H:i:s',
         'created_at' => 'datetime:Y-m-d H:i:s',

--- a/src/Models/JobStatus.php
+++ b/src/Models/JobStatus.php
@@ -83,6 +83,11 @@ class JobStatus extends Model
         return $this->hasMany(JobStatusStatus::class);
     }
 
+    public function users()
+    {
+        return $this->hasMany(JobStatusUser::class);
+    }
+
     public static function newFactory()
     {
         return JobStatusFactory::new();

--- a/src/Models/JobStatusUser.php
+++ b/src/Models/JobStatusUser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JobStatus\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use JobStatus\Database\Factories\JobStatusTagFactory;
+use JobStatus\Database\Factories\JobStatusUserFactory;
+
+/**
+ * @property string $key The key of the tag
+ * @property string $value The value of the tag
+ */
+class JobStatusUser extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id', 'job_status_id',
+    ];
+
+    protected $casts = [];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_status_users');
+        parent::__construct($attributes);
+    }
+
+    public function jobStatus()
+    {
+        return $this->belongsTo(JobStatus::class);
+    }
+
+    protected static function newFactory()
+    {
+        return new JobStatusUserFactory();
+    }
+
+}

--- a/src/Search/JobStatusSearcher.php
+++ b/src/Search/JobStatusSearcher.php
@@ -27,9 +27,11 @@ class JobStatusSearcher
         return $this;
     }
 
-    public function forUser(int $userId): JobStatusSearcher
+    public function forUser(?int $userId): JobStatusSearcher
     {
-        $this->searchParameters->pushUser($userId);
+        if($userId) {
+            $this->searchParameters->pushUser($userId);
+        }
 
         return $this;
     }

--- a/src/Search/JobStatusSearcher.php
+++ b/src/Search/JobStatusSearcher.php
@@ -118,4 +118,11 @@ class JobStatusSearcher
 
         return $this;
     }
+
+    public function withoutUserLimit(): JobStatusSearcher
+    {
+        $this->searchParameters->setWithoutUserLimit(true);
+
+        return $this;
+    }
 }

--- a/src/Search/JobStatusSearcher.php
+++ b/src/Search/JobStatusSearcher.php
@@ -27,6 +27,13 @@ class JobStatusSearcher
         return $this;
     }
 
+    public function forUser(int $userId): JobStatusSearcher
+    {
+        $this->searchParameters->pushUser($userId);
+
+        return $this;
+    }
+
     public function whereJobClass(string $jobClass): JobStatusSearcher
     {
         $this->searchParameters->setJobClass($jobClass);

--- a/src/Search/QueryFactory.php
+++ b/src/Search/QueryFactory.php
@@ -3,6 +3,7 @@
 namespace JobStatus\Search;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Gate;
 use JobStatus\Models\JobStatus;
 
 class QueryFactory
@@ -82,13 +83,15 @@ class QueryFactory
 
     private static function addUserIds(Builder $query, SearchParameters $parameters): Builder
     {
-        $query->where(function(Builder $query) use ($parameters) {
-            $users = $parameters->getUsers();
-            $query->whereHas('users', function(Builder $query) use ($users) {
-                $query->whereIn('user_id', $users);
-            })
-                ->orWhere('public', true);
-        });
+        if(!Gate::allows('viewJobStatus')) {
+            $query->where(function(Builder $query) use ($parameters) {
+                $users = $parameters->getUsers();
+                $query->whereHas('users', function(Builder $query) use ($users) {
+                    $query->whereIn('user_id', $users);
+                })
+                    ->orWhere('public', true);
+            });
+        }
 
 
         return $query;

--- a/src/Search/QueryFactory.php
+++ b/src/Search/QueryFactory.php
@@ -16,6 +16,7 @@ class QueryFactory
         $query = static::addStatuses($query, $parameters);
         $query = static::addUuid($query, $parameters);
         $query = static::addUpdatedBefore($query, $parameters);
+        $query = static::addUserIds($query, $parameters);
 
         return $query;
     }
@@ -75,6 +76,20 @@ class QueryFactory
         if ($parameters->getUpdatedBefore() !== null) {
             $query->where('updated_at', '<', $parameters->getUpdatedBefore());
         }
+
+        return $query;
+    }
+
+    private static function addUserIds(Builder $query, SearchParameters $parameters): Builder
+    {
+        $query->where(function(Builder $query) use ($parameters) {
+            foreach($parameters->getUsers() as $userId) {
+                $query->orWhereHas('users', function(Builder $query) use ($userId) {
+                    $query->where('user_id', $userId);
+                });
+            }
+        });
+
 
         return $query;
     }

--- a/src/Search/QueryFactory.php
+++ b/src/Search/QueryFactory.php
@@ -89,7 +89,7 @@ class QueryFactory
                 $query->whereHas('users', function (Builder $query) use ($users) {
                     $query->whereIn('user_id', $users);
                 })
-                    ->orWhere('public', true);
+                        ->orWhere('public', true);
             });
         }
 

--- a/src/Search/QueryFactory.php
+++ b/src/Search/QueryFactory.php
@@ -83,11 +83,11 @@ class QueryFactory
     private static function addUserIds(Builder $query, SearchParameters $parameters): Builder
     {
         $query->where(function(Builder $query) use ($parameters) {
-            foreach($parameters->getUsers() as $userId) {
-                $query->orWhereHas('users', function(Builder $query) use ($userId) {
-                    $query->where('user_id', $userId);
-                });
-            }
+            $users = $parameters->getUsers();
+            $query->whereHas('users', function(Builder $query) use ($users) {
+                $query->whereIn('user_id', $users);
+            })
+                ->orWhere('public', true);
         });
 
 

--- a/src/Search/QueryFactory.php
+++ b/src/Search/QueryFactory.php
@@ -83,7 +83,7 @@ class QueryFactory
 
     private static function addUserIds(Builder $query, SearchParameters $parameters): Builder
     {
-        if(!Gate::allows('viewJobStatus')) {
+        if($parameters->isWithoutUserLimit() === false) {
             $query->where(function(Builder $query) use ($parameters) {
                 $users = $parameters->getUsers();
                 $query->whereHas('users', function(Builder $query) use ($users) {

--- a/src/Search/Result/JobRun.php
+++ b/src/Search/Result/JobRun.php
@@ -164,10 +164,10 @@ class JobRun implements Arrayable, Jsonable
         return $this->jobStatus->status;
     }
 
-    public function accessibleBy(int $userId): bool
+    public function accessibleBy(?int $userId): bool
     {
-        return $this->jobStatus->users()->where('user_id', $userId)->exists()
-            || $this->trackingIsPublic();
+        return $this->trackingIsPublic()
+            || $this->jobStatus->users()->where('user_id', $userId)->exists();
     }
 
     public function trackingIsPublic(): bool

--- a/src/Search/Result/JobRun.php
+++ b/src/Search/Result/JobRun.php
@@ -163,4 +163,15 @@ class JobRun implements Arrayable, Jsonable
     {
         return $this->jobStatus->status;
     }
+
+    public function accessibleBy(int $userId): bool
+    {
+        return $this->jobStatus->users()->where('user_id', $userId)->exists()
+            || $this->trackingIsPublic();
+    }
+
+    public function trackingIsPublic(): bool
+    {
+        return $this->jobStatus->public;
+    }
 }

--- a/src/Search/SearchParameters.php
+++ b/src/Search/SearchParameters.php
@@ -15,6 +15,8 @@ class SearchParameters
 
     private ?string $uuid = null;
 
+    private array $users = [];
+
     private ?Carbon $updatedBefore = null;
 
     /**
@@ -149,5 +151,17 @@ class SearchParameters
         $this->updatedBefore = $updatedBefore;
 
         return $this;
+    }
+
+    public function pushUser(int $userId): SearchParameters
+    {
+        $this->users[] = $userId;
+
+        return $this;
+    }
+
+    public function getUsers(): array
+    {
+        return $this->users;
     }
 }

--- a/src/Search/SearchParameters.php
+++ b/src/Search/SearchParameters.php
@@ -29,6 +29,8 @@ class SearchParameters
      */
     private array $excludeStatus = [];
 
+    private bool $withoutUserLimit = false;
+
     public function __construct()
     {
         $this->tagsSearchParameters = new TagsSearchParameters();
@@ -164,4 +166,18 @@ class SearchParameters
     {
         return $this->users;
     }
+
+    public function setWithoutUserLimit(bool $withoutUserLimit)
+    {
+        $this->withoutUserLimit = $withoutUserLimit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isWithoutUserLimit(): bool
+    {
+        return $this->withoutUserLimit;
+    }
+
 }

--- a/tests/Feature/Http/Api/JobSignalStoreTest.php
+++ b/tests/Feature/Http/Api/JobSignalStoreTest.php
@@ -148,6 +148,20 @@ class JobSignalStoreTest extends TestCase
     }
 
     /** @test */
+    public function it_denies_access_to_an_anonymous_user_to_the_private_job()
+    {
+        $jobStatus = JobStatus::factory()->create(['public' => false]);
+        JobStatusUser::factory()->create(['user_id' => 2, 'job_status_id' => $jobStatus->id]);
+
+        $response = $this->postJson(route('job-status.job-signal.store', $jobStatus->id), [
+            'signal' => 'custom-signal',
+            'cancel_job' => true,
+            'parameters' => ['param1' => 'value1'],
+        ]);
+        $response->assertForbidden();
+    }
+
+    /** @test */
     public function it_gives_access_to_a_user_to_the_public_job()
     {
         $jobStatus = JobStatus::factory()->create(['public' => true]);

--- a/tests/Feature/Listeners/Workflow/SyncQueueTest.php
+++ b/tests/Feature/Listeners/Workflow/SyncQueueTest.php
@@ -18,6 +18,7 @@ class SyncQueueTest extends TestCase
             ->setAlias('my-fake-job')
             ->setTags(['my-first-tag' => 1, 'my-second-tag' => 'mytag-value'])
             ->setCallback(static::class . '@a_run_is_handled_callback')
+            ->setUsers([1,2])
             ->dispatchSync();
 
         $this->assertNull(JobStatus::first()->exception, JobStatus::first()->exception?->message ?? 'An error occured');
@@ -40,6 +41,10 @@ class SyncQueueTest extends TestCase
         Assert::assertEquals(1, $jobStatus->tags[0]->value);
         Assert::assertEquals('my-second-tag', $jobStatus->tags[1]->key);
         Assert::assertEquals('mytag-value', $jobStatus->tags[1]->value);
+
+        Assert::assertCount(2, $jobStatus->users()->get());
+        Assert::assertEquals(1, $jobStatus->users()->get()[0]->user_id);
+        Assert::assertEquals(2, $jobStatus->users()->get()[1]->user_id);
 
         Assert::assertCount(0, $jobStatus->messages()->orderBy('id')->get());
 
@@ -247,6 +252,8 @@ class SyncQueueTest extends TestCase
                 ->setCallback(static::class . '@a_failed_run_is_handled_callback')
                 ->maxTries(1)
                 ->maxExceptions(1)
+                ->setUsers([1,2])
+                ->setPublic(true)
                 ->dispatchSync();
         } catch (\Exception $e) {
             $this->assertEquals(\Exception::class, get_class($e));
@@ -265,12 +272,17 @@ class SyncQueueTest extends TestCase
         $this->assertEquals('', $jobStatus->job_id);
         $this->assertEquals('sync', $jobStatus->connection_name);
         $this->assertNotNull($jobStatus->uuid);
+        $this->assertEquals(true, $jobStatus->public);
 
         $this->assertCount(2, $jobStatus->tags);
         $this->assertEquals('my-first-tag', $jobStatus->tags[0]->key);
         $this->assertEquals(1, $jobStatus->tags[0]->value);
         $this->assertEquals('my-second-tag', $jobStatus->tags[1]->key);
         $this->assertEquals('mytag-value', $jobStatus->tags[1]->value);
+
+        $this->assertCount(2, $jobStatus->users()->get());
+        $this->assertEquals(1, $jobStatus->users()->get()[0]->user_id);
+        $this->assertEquals(2, $jobStatus->users()->get()[1]->user_id);
 
         $this->assertNotNull($jobStatus->exception);
         $this->assertEquals('Test', $jobStatus->exception->message);
@@ -307,6 +319,8 @@ class SyncQueueTest extends TestCase
                 ->setTags(['my-first-tag' => 1, 'my-second-tag' => 'mytag-value'])
                 ->maxTries(2)
                 ->maxExceptions(2)
+                ->setUsers([1,2])
+                ->setPublic(false)
                 ->setCallback(static::class . '@a_failed_and_retry_run_is_handled_callback')
                 ->dispatchSync();
         } catch (\Exception $e) {
@@ -326,6 +340,11 @@ class SyncQueueTest extends TestCase
         $this->assertEquals('', $jobStatus->job_id);
         $this->assertEquals('sync', $jobStatus->connection_name);
         $this->assertNotNull($jobStatus->uuid);
+        $this->assertEquals(false, $jobStatus->public);
+
+        $this->assertCount(2, $jobStatus->users()->get());
+        $this->assertEquals(1, $jobStatus->users()->get()[0]->user_id);
+        $this->assertEquals(2, $jobStatus->users()->get()[1]->user_id);
 
         $this->assertCount(2, $jobStatus->tags);
         $this->assertEquals('my-first-tag', $jobStatus->tags[0]->key);

--- a/tests/Feature/Search/JobStatusJobRunTest.php
+++ b/tests/Feature/Search/JobStatusJobRunTest.php
@@ -394,8 +394,8 @@ class JobStatusJobRunTest extends TestCase
     }
 
     /** @test */
-    public function accessible_by_returns_false_if_the_user_can_see_the_job(){
-        $status = JobStatus::factory()->create();
+    public function accessible_by_returns_false_if_the_user_cannot_see_the_job(){
+        $status = JobStatus::factory()->create(['public' => false]);
         JobStatusUser::factory()->create(['job_status_id' => $status->id, 'user_id' => 2]);
 
         $this->assertFalse((new JobRun($status))->accessibleBy(1));

--- a/tests/Feature/Search/JobStatusJobRunTest.php
+++ b/tests/Feature/Search/JobStatusJobRunTest.php
@@ -39,6 +39,27 @@ class JobStatusJobRunTest extends TestCase
     }
 
     /** @test */
+    public function is_a_retry_returns_true_if_a_parent_is_set()
+    {
+        $mainJobStatus = JobStatus::factory()->create();
+        $parentJobStatus = JobStatus::factory()->create();
+
+        $run = new JobRun($mainJobStatus, new JobRun($parentJobStatus));
+
+        $this->assertTrue($run->isARetry());
+    }
+
+    /** @test */
+    public function is_a_retry_returns_false_if_a_parent_is_not_set()
+    {
+        $mainJobStatus = JobStatus::factory()->create();
+
+        $run = new JobRun($mainJobStatus, null);
+
+        $this->assertFalse($run->isARetry());
+    }
+
+    /** @test */
     public function parent_returns_the_parent()
     {
         $mainJobStatus = JobStatus::factory()->create();

--- a/tests/Feature/Search/JobStatusJobRunTest.php
+++ b/tests/Feature/Search/JobStatusJobRunTest.php
@@ -386,15 +386,15 @@ class JobStatusJobRunTest extends TestCase
     }
 
     /** @test */
-    public function accessible_by_returns_true_if_the_user_can_see_the_job(){
-        $status = JobStatus::factory()->create();
+    public function accessible_by_returns_true_if_the_user_can_see_the_private_job(){
+        $status = JobStatus::factory()->create(['public' => false]);
         JobStatusUser::factory()->create(['job_status_id' => $status->id, 'user_id' => 1]);
 
         $this->assertTrue((new JobRun($status))->accessibleBy(1));
     }
 
     /** @test */
-    public function accessible_by_returns_false_if_the_user_cannot_see_the_job(){
+    public function accessible_by_returns_false_if_the_user_cannot_see_the_private_job(){
         $status = JobStatus::factory()->create(['public' => false]);
         JobStatusUser::factory()->create(['job_status_id' => $status->id, 'user_id' => 2]);
 
@@ -402,9 +402,9 @@ class JobStatusJobRunTest extends TestCase
     }
 
     /** @test */
-    public function accessible_by_returns_true_if_there_are_no_entries(){
-        $status = JobStatus::factory()->create();
+    public function accessible_by_returns_true_if_the_job_is_public(){
+        $status = JobStatus::factory()->create(['public' => true]);
 
-        $this->assertFalse((new JobRun($status))->accessibleBy(1));
+        $this->assertTrue((new JobRun($status))->accessibleBy(1));
     }
 }

--- a/tests/Feature/Search/JobStatusJobRunTest.php
+++ b/tests/Feature/Search/JobStatusJobRunTest.php
@@ -11,6 +11,7 @@ use JobStatus\Models\JobSignal;
 use JobStatus\Models\JobStatus;
 use JobStatus\Models\JobStatusStatus;
 use JobStatus\Models\JobStatusTag;
+use JobStatus\Models\JobStatusUser;
 use JobStatus\Search\Result\JobRun;
 use JobStatus\Tests\TestCase;
 
@@ -382,5 +383,28 @@ class JobStatusJobRunTest extends TestCase
             'material'=> 'Aluminium',
             'pedals'=> 'spd',
         ], (new JobRun($status))->getTagsAsArray());
+    }
+
+    /** @test */
+    public function accessible_by_returns_true_if_the_user_can_see_the_job(){
+        $status = JobStatus::factory()->create();
+        JobStatusUser::factory()->create(['job_status_id' => $status->id, 'user_id' => 1]);
+
+        $this->assertTrue((new JobRun($status))->accessibleBy(1));
+    }
+
+    /** @test */
+    public function accessible_by_returns_false_if_the_user_can_see_the_job(){
+        $status = JobStatus::factory()->create();
+        JobStatusUser::factory()->create(['job_status_id' => $status->id, 'user_id' => 2]);
+
+        $this->assertFalse((new JobRun($status))->accessibleBy(1));
+    }
+
+    /** @test */
+    public function accessible_by_returns_true_if_there_are_no_entries(){
+        $status = JobStatus::factory()->create();
+
+        $this->assertFalse((new JobRun($status))->accessibleBy(1));
     }
 }

--- a/tests/Feature/Search/JobStatusResultsTest.php
+++ b/tests/Feature/Search/JobStatusResultsTest.php
@@ -306,4 +306,5 @@ class JobStatusResultsTest extends TestCase
 
         $this->assertEquals(collect($array)->toJson(), $results->toJson());
     }
+
 }

--- a/tests/Feature/Search/JobStatusSearcherTest.php
+++ b/tests/Feature/Search/JobStatusSearcherTest.php
@@ -179,21 +179,22 @@ class JobStatusSearcherTest extends TestCase
     public function it_filters_by_connected_users()
     {
         $set1 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 1]), 'users')
-            ->count(3)->create();
+            ->count(3)->create(['public' => false]);
         $set2 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 2]), 'users')
-            ->count(7)->create();
+            ->count(7)->create(['public' => false]);
+        $set3 = JobStatus::factory()->count(4)->create(['public' => true]);
 
         $results = (new JobStatusSearcher())->forUser(1)->get()->raw();
-        $this->assertCount(3, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set1->pluck('id')->sort()->values());
+        $this->assertCount(7, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set1->merge($set3)->pluck('id')->sort()->values());
 
         $results = (new JobStatusSearcher())->forUser(2)->get()->raw();
-        $this->assertCount(7, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->pluck('id')->sort()->values());
+        $this->assertCount(11, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set3)->pluck('id')->sort()->values());
 
 
         $results = (new JobStatusSearcher())->forUser(1)->forUser(2)->get()->raw();
-        $this->assertCount(10, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->pluck('id')->sort()->values());
+        $this->assertCount(14, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
     }
 }

--- a/tests/Feature/Search/JobStatusSearcherTest.php
+++ b/tests/Feature/Search/JobStatusSearcherTest.php
@@ -199,31 +199,4 @@ class JobStatusSearcherTest extends TestCase
         $this->assertCount(14, $results);
         $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
     }
-
-    /** @test */
-    public function if_the_gate_allows_the_current_user_all_jobs_can_be_seen()
-    {
-        $set1 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 1]), 'users')
-            ->count(3)->create(['public' => false]);
-        $set2 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 2]), 'users')
-            ->count(7)->create(['public' => false]);
-        $set3 = JobStatus::factory()->count(4)->create(['public' => true]);
-
-        $gate = $this->prophesize(GateContract::class);
-        $gate->allows('viewJobStatus')->willReturn(true);
-        $this->app->instance(GateContract::class, $gate->reveal());
-
-        $results = (new JobStatusSearcher())->forUser(1)->get()->raw();
-        $this->assertCount(14, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
-
-        $results = (new JobStatusSearcher())->forUser(2)->get()->raw();
-        $this->assertCount(14, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
-
-
-        $results = (new JobStatusSearcher())->forUser(1)->forUser(2)->get()->raw();
-        $this->assertCount(14, $results);
-        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
-    }
 }

--- a/tests/Feature/Search/JobStatusSearcherTest.php
+++ b/tests/Feature/Search/JobStatusSearcherTest.php
@@ -3,6 +3,8 @@
 namespace JobStatus\Tests\Feature\Search;
 
 use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use JobStatus\Models\JobStatus;
 use JobStatus\Models\JobStatusTag;
@@ -191,6 +193,33 @@ class JobStatusSearcherTest extends TestCase
         $results = (new JobStatusSearcher())->forUser(2)->get()->raw();
         $this->assertCount(11, $results);
         $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set3)->pluck('id')->sort()->values());
+
+
+        $results = (new JobStatusSearcher())->forUser(1)->forUser(2)->get()->raw();
+        $this->assertCount(14, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
+    }
+
+    /** @test */
+    public function if_the_gate_allows_the_current_user_all_jobs_can_be_seen()
+    {
+        $set1 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 1]), 'users')
+            ->count(3)->create(['public' => false]);
+        $set2 = JobStatus::factory()->has(JobStatusUser::factory()->state(['user_id' => 2]), 'users')
+            ->count(7)->create(['public' => false]);
+        $set3 = JobStatus::factory()->count(4)->create(['public' => true]);
+
+        $gate = $this->prophesize(GateContract::class);
+        $gate->allows('viewJobStatus')->willReturn(true);
+        $this->app->instance(GateContract::class, $gate->reveal());
+
+        $results = (new JobStatusSearcher())->forUser(1)->get()->raw();
+        $this->assertCount(14, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
+
+        $results = (new JobStatusSearcher())->forUser(2)->get()->raw();
+        $this->assertCount(14, $results);
+        $this->assertEquals($results->pluck('id')->sort()->values(), $set2->merge($set1)->merge($set3)->pluck('id')->sort()->values());
 
 
         $results = (new JobStatusSearcher())->forUser(1)->forUser(2)->get()->raw();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,9 +37,4 @@ class TestCase extends \Orchestra\Testbench\TestCase
         ]);
     }
 
-    protected function tearDown(): void
-    {
-        JobFake::$canSeeTracking = null;
-        parent::tearDown();
-    }
 }

--- a/tests/Unit/JobStatusModifierTest.php
+++ b/tests/Unit/JobStatusModifierTest.php
@@ -395,7 +395,8 @@ class JobStatusModifierTest extends TestCase
     }
 
     /** @test */
-    public function cancel_does_nothing_if_no_job_status_set(){
+    public function cancel_does_nothing_if_no_job_status_set()
+    {
         $modifier = new JobStatusModifier(null);
         $modifier->cancel(['param1' => 'value1']);
 

--- a/tests/Unit/JobStatusModifierTest.php
+++ b/tests/Unit/JobStatusModifierTest.php
@@ -8,6 +8,7 @@ use JobStatus\Enums\Status;
 use JobStatus\JobStatusModifier;
 use JobStatus\Models\JobException;
 use JobStatus\Models\JobStatus;
+use JobStatus\Models\JobStatusUser;
 use JobStatus\Tests\TestCase;
 
 class JobStatusModifierTest extends TestCase
@@ -379,5 +380,17 @@ class JobStatusModifierTest extends TestCase
             'cancel_job' => true,
             'parameters' => json_encode(['param1' => 'value1']),
         ]);
+    }
+
+    /** @test */
+    public function a_user_id_can_be_pushed()
+    {
+        $jobStatus = JobStatus::factory()->create();
+
+        $modifier = new JobStatusModifier($jobStatus);
+
+        $this->assertFalse(JobStatusUser::where('user_id', 2)->where('job_status_id', $jobStatus->id)->exists());
+        $modifier->grantAccessTo(2);
+        $this->assertTrue(JobStatusUser::where('user_id', 2)->where('job_status_id', $jobStatus->id)->exists());
     }
 }

--- a/tests/Unit/JobStatusModifierTest.php
+++ b/tests/Unit/JobStatusModifierTest.php
@@ -393,4 +393,12 @@ class JobStatusModifierTest extends TestCase
         $modifier->grantAccessTo(2);
         $this->assertTrue(JobStatusUser::where('user_id', 2)->where('job_status_id', $jobStatus->id)->exists());
     }
+
+    /** @test */
+    public function cancel_does_nothing_if_no_job_status_set(){
+        $modifier = new JobStatusModifier(null);
+        $modifier->cancel(['param1' => 'value1']);
+
+        $this->assertDatabaseEmpty(sprintf('%s_%s', config('laravel-job-status.table_prefix'), 'job_signals'));
+    }
 }

--- a/tests/Unit/Models/JobStatusTest.php
+++ b/tests/Unit/Models/JobStatusTest.php
@@ -9,6 +9,7 @@ use JobStatus\Models\JobSignal;
 use JobStatus\Models\JobStatus;
 use JobStatus\Models\JobStatusStatus;
 use JobStatus\Models\JobStatusTag;
+use JobStatus\Models\JobStatusUser;
 use JobStatus\Tests\TestCase;
 
 class JobStatusTest extends TestCase
@@ -139,4 +140,23 @@ class JobStatusTest extends TestCase
         $this->assertEquals(24, $finishedAt->second);
         $this->assertEquals(234, $finishedAt->millisecond);
     }
+
+    /** @test */
+    public function it_has_many_users()
+    {
+        $status = JobStatus::factory()->create();
+        $status1 = JobStatusUser::factory()->create(['user_id' => 1, 'job_status_id' => $status->id]);
+        $status2 = JobStatusUser::factory()->create(['user_id' => 2, 'job_status_id' => $status->id]);
+        $status3 = JobStatusUser::factory()->create(['user_id' => 3, 'job_status_id' => $status->id]);
+        $status4 = JobStatusUser::factory()->create(['user_id' => 4, 'job_status_id' => $status->id]);
+        JobStatusStatus::factory()->count(10)->create();
+
+        $this->assertEquals(4, $status->users()->count());
+        $retrieved = $status->users()->orderBy('id')->get();
+        $this->assertTrue($status1->is($retrieved->shift()));
+        $this->assertTrue($status2->is($retrieved->shift()));
+        $this->assertTrue($status3->is($retrieved->shift()));
+        $this->assertTrue($status4->is($retrieved->shift()));
+    }
+
 }

--- a/tests/Unit/Models/JobStatusUserTest.php
+++ b/tests/Unit/Models/JobStatusUserTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JobStatus\Tests\Unit\Models;
+
+use Carbon\Carbon;
+use JobStatus\Models\JobMessage;
+use JobStatus\Models\JobStatus;
+use JobStatus\Models\JobStatusUser;
+use JobStatus\Tests\TestCase;
+
+class JobStatusUserTest extends TestCase
+{
+    /** @test */
+    public function a_model_can_be_created()
+    {
+        $attributes = [
+            'user_id' => 1,
+            'job_status_id' => JobStatus::factory()->create()->id,
+        ];
+
+        JobStatusUser::factory()->create($attributes);
+        $this->assertDatabaseHas('job_status_job_status_users', $attributes);
+    }
+
+    /** @test */
+    public function it_has_a_relationship_with_job_status()
+    {
+        $jobStatus = JobStatus::factory()->create();
+        $user = JobStatusUser::factory()->create(['job_status_id' => $jobStatus->id]);
+
+        $this->assertTrue(
+            $jobStatus->is(
+                $user->jobStatus
+            )
+        );
+    }
+
+}

--- a/tests/fakes/JobFake.php
+++ b/tests/fakes/JobFake.php
@@ -12,8 +12,6 @@ class JobFake implements ShouldQueue
 {
     use Dispatchable, Trackable, InteractsWithQueue, Queueable;
 
-    public static string|\Closure|null $canSeeTracking;
-
     public int $maxExceptions = 3;
 
     public int $tries = 3;
@@ -22,8 +20,15 @@ class JobFake implements ShouldQueue
         private ?string $alias = null,
         private array $tags = [],
         private \Closure|string|null $callback = null,
-        private array $signals = []
+        private array $signals = [],
+        private array $users = [],
+        private bool $public = true,
     ) {
+    }
+
+    public function public(): bool
+    {
+        return $this->public;
     }
 
     public function alias(): ?string
@@ -52,13 +57,9 @@ class JobFake implements ShouldQueue
         }
     }
 
-
-    public static function canSeeTracking($user = null, array $tags = []): bool
+    public function users(): array
     {
-        if (isset(static::$canSeeTracking)) {
-            return call_user_func(static::$canSeeTracking, $user, $tags);
-        }
-
-        return true;
+        return $this->users;
     }
+
 }

--- a/tests/fakes/JobFakeFactory.php
+++ b/tests/fakes/JobFakeFactory.php
@@ -15,13 +15,14 @@ class JobFakeFactory
 
     private \Closure|string|null $callback = null;
 
-    private ?\Closure $canSeeTracking = null;
-
     private array $signals = [];
 
     private int $maxExceptions = 3;
 
     private int $tries = 3;
+
+    private array $users = [];
+    private bool $public = true;
 
     /**
      * @return int
@@ -99,33 +100,24 @@ class JobFakeFactory
         return $this;
     }
 
-    /**
-     * @return \Closure|null
-     */
-    public function getCanSeeTracking(): ?\Closure
+    public function setPublic(bool $public): JobFakeFactory
     {
-        return $this->canSeeTracking;
+        $this->public = $public;
+
+        return $this;
     }
 
-    /**
-     * @param \Closure|null $canSeeTracking
-     * @return JobFakeFactory
-     */
-    public function setCanSeeTracking(?\Closure $canSeeTracking): JobFakeFactory
+    public function setUsers(array $users): JobFakeFactory
     {
-        $this->canSeeTracking = $canSeeTracking;
-
+        $this->users = $users;
         return $this;
     }
 
     public function create(): JobFake
     {
-        $job = new JobFake($this->alias, $this->tags, $this->callback ?? static::class . '@fakeCallback', $this->signals);
+        $job = new JobFake($this->alias, $this->tags, $this->callback ?? static::class . '@fakeCallback', $this->signals, $this->users, $this->public);
         $job->maxExceptions = $this->maxExceptions;
         $job->tries = $this->tries;
-        if ($this->canSeeTracking) {
-            $job::$canSeeTracking = $this->canSeeTracking;
-        }
 
         return $job;
     }


### PR DESCRIPTION
By default, all users can see all jobs.

Add 
```
public function public() {
    return false
}
```
to make your job hidden from everyone. 


To only allow certain users to view the job, make sure it is not public and return the user IDs

```
public function users(): array
{
    return [1, 2, 3]; // Users 1 and 3 can see the job, others can't
}
```

Use `->withoutUserLimit()` as a search parameter to show all jobs regardless of the current user