### PR TITLE
Add `--force` option to `job-status:clear` command

### DIFF
--- a/docs/docs/clearing.md
+++ b/docs/docs/clearing.md
@@ -27,6 +27,12 @@ To keep a high level overview of your job history, you can choose to just delete
 
 To turn on trimming, pass the `--trim` flag to the command.
 
+### Wipe all data
+
+When developing `laravel-job-status`, or for other reasons - you might want to wipe all job status data from your database.
+
+To do this, pass the option `--force`, this will remove all constraints when searching for job status data to prune.
+
 ## Scheduling the command
 
 Often your real use case is more complex than the above examples. We may want to preserve a week of analytics at a time, and preserve failed jobs until you can debug them, but otherwise limit the stored data.

--- a/src/Console/ClearJobStatusCommand.php
+++ b/src/Console/ClearJobStatusCommand.php
@@ -16,7 +16,8 @@ class ClearJobStatusCommand extends Command
     protected $signature = 'job-status:clear 
                             {--preserve=:Any jobs that were finished less than this number of hours ago will be kept}
                             {--trim : Only remove the excess information from jobs and keep the core data}
-                            {--keep-failed : Keep all failed jobs}';
+                            {--keep-failed : Keep all failed jobs}
+                            {--force : Wipe everything}';
 
     /**
      * The console command description.
@@ -43,13 +44,15 @@ class ClearJobStatusCommand extends Command
         $hours = (int) $this->option('preserve') ?? 0;
 
         $statuses = JobStatus::query();
-        if ($this->option('keep-failed')) {
-            $statuses->whereStatusIn([Status::SUCCEEDED, Status::CANCELLED]);
-        } else {
-            $statuses->whereFinished();
-        }
-        if ($hours !== 0) {
-            $statuses->where('updated_at', '<', now()->subHours($hours));
+        if (!$this->option('force')) {
+            if ($this->option('keep-failed')) {
+                $statuses->whereStatusIn([Status::SUCCEEDED, Status::CANCELLED]);
+            } else {
+                $statuses->whereFinished();
+            }
+            if ($hours !== 0) {
+                $statuses->where('updated_at', '<', now()->subHours($hours));
+            }
         }
         $statuses = $statuses->get();
 


### PR DESCRIPTION
I was unable to "start again" after stopping jobs midway / clearing my queuing system, and had leftover artefacts in the database.

This will ignore all the constraints when searching for job data to prune and remove everything.

Hopefully this is useful to others!