### PR TITLE
Use the queue default connection name where possible

### DIFF
--- a/src/Listeners/JobQueued.php
+++ b/src/Listeners/JobQueued.php
@@ -53,7 +53,7 @@ class JobQueued
                 'percentage' => 0,
                 'queue' => (property_exists($job, 'job') && $job?->job && $job->job?->getQueue())
                     ? $job->job->getQueue()
-                    : $job?->queue ?? $job?->queue ?? null,
+                    : $job?->queue ?? $job?->queue ?? config(sprintf('queue.connections.%s.queue', $event->connectionName), null),
                 'payload' => ((property_exists($job, 'job') && $job?->job && $job->job?->getQueue())
                     ? $job->job?->payload()
                     : null),

--- a/tests/Feature/Listeners/Workflow/DatabaseQueueTest.php
+++ b/tests/Feature/Listeners/Workflow/DatabaseQueueTest.php
@@ -1955,4 +1955,22 @@ class DatabaseQueueTest extends TestCase
 
         $jobRun->retry();
     }
+
+    /** @test */
+    public function it_assigns_the_default_queue_name_to_the_queue_if_no_queue_specified()
+    {
+        config()->set('laravel-job-status.track_anonymous', true);
+
+        $job = (new JobFakeFactory())
+            ->setAlias('my-fake-job')
+            ->setTags(['my-first-tag' => 1, 'my-second-tag' => 'mytag-value', 'my-indexless-tag'])
+            ->setUsers([1, 2])
+            ->setIsUnprotected(true)
+            ->dispatch(0);
+
+        $this->assertCount(1, JobStatus::all());
+        $this->assertEquals('default', JobStatus::first()->queue);
+
+    }
+
 }

--- a/tests/Feature/Listeners/Workflow/ListenerQueueTest.php
+++ b/tests/Feature/Listeners/Workflow/ListenerQueueTest.php
@@ -873,7 +873,7 @@ class ListenerQueueTest extends TestCase
     public function cannot_retry_a_queued_job()
     {
         $this->expectException(\JobStatus\Exceptions\CannotBeRetriedException::class);
-        $this->expectExceptionMessage('All the following fields must be given: Queue, Payload');
+        $this->expectExceptionMessage('All the following fields must be given: Payload');
 
         (new JobFakeFactory())
             ->setAlias('my-fake-listener')
@@ -882,7 +882,6 @@ class ListenerQueueTest extends TestCase
             ->maxExceptions(1)
             ->setUsers([1, 2])
             ->setIsUnprotected(true)
-            ->onQueue('my-database-queue')
             ->dispatchAsListener(0);
 
 
@@ -892,7 +891,7 @@ class ListenerQueueTest extends TestCase
                 0,
                 fn (AssertJobStatus $jobStatus) => $jobStatus
                     ->missingPayload()
-                    ->hasQueue(null)
+                    ->hasQueue('default')
                     ->hasClass(ListenerFake::class)
                     ->hasAlias('my-fake-listener')
                     ->hasStatus(Status::QUEUED)


### PR DESCRIPTION
Jobs with no specified queue have `queue` as null until it starts running. This PR instead assigns the default queue name